### PR TITLE
fix: return empty array if images null

### DIFF
--- a/src/utils/parsingUtils.ts
+++ b/src/utils/parsingUtils.ts
@@ -522,7 +522,9 @@ function parseInteractiveGuideFinish(finishStep: any) {
     displayShare,
     shareTitle,
     shareImage: parseInteractiveGuideImage(shareImage),
-    images: images.map((img: any) => parseInteractiveGuideImage(img.image)),
+    images: images ? 
+      images.map((img: any) => parseInteractiveGuideImage(img.image))
+      : [],
   };
 }
 


### PR DESCRIPTION
Fixes case where parsing for interactive guides failed, and hence returned nothing, when `images` where undefined/null.